### PR TITLE
New methods to add custom regex, matching to existing or new tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,16 @@
                 
                 </li>
               
+                
+                <li><a
+                  href='#addregex'
+                  class="">
+                  addRegex
+                  
+                </a>
+                
+                </li>
+              
             </ul>
           </div>
           <div class='mt1 h6 quiet'>
@@ -112,7 +122,7 @@
   
     <h1>wink-tokenizer</h1>
 <p>Multilingual tokenizer that automatically tags each token with its type</p>
-<h3><a href="https://travis-ci.org/winkjs/wink-tokenizer"><img src="https://api.travis-ci.org/winkjs/wink-tokenizer.svg?branch=master" alt="Build Status"></a> <a href="https://coveralls.io/github/winkjs/wink-tokenizer?branch=master"><img src="https://coveralls.io/repos/github/winkjs/wink-tokenizer/badge.svg?branch=master" alt="Coverage Status"></a> <a href="http://inch-ci.org/github/winkjs/wink-tokenizer"><img src="http://inch-ci.org/github/winkjs/wink-tokenizer.svg?branch=master" alt="Inline docs"></a> <a href="https://david-dm.org/winkjs/wink-tokenizer?type=dev"><img src="https://david-dm.org/winkjs/wink-tokenizer/dev-status.svg" alt="devDependencies Status"></a></h3>
+<h3><a href="https://travis-ci.org/winkjs/wink-tokenizer"><img src="https://api.travis-ci.org/winkjs/wink-tokenizer.svg?branch=master" alt="Build Status"></a> <a href="https://coveralls.io/github/winkjs/wink-tokenizer?branch=master"><img src="https://coveralls.io/repos/github/winkjs/wink-tokenizer/badge.svg?branch=master" alt="Coverage Status"></a> <a href="http://inch-ci.org/github/winkjs/wink-tokenizer"><img src="http://inch-ci.org/github/winkjs/wink-tokenizer.svg?branch=master" alt="Inline docs"></a> <a href="https://david-dm.org/winkjs/wink-tokenizer?type=dev"><img src="https://david-dm.org/winkjs/wink-tokenizer/dev-status.svg" alt="devDependencies Status"></a> <a href="https://gitter.im/winkjs/Lobby"><img src="https://img.shields.io/gitter/room/nwjs/nw.js.svg" alt="Gitter"></a></h3>
 <p><a href="http://winkjs.org/"><img align="right" src="https://decisively.github.io/wink-logos/logo-title.png" width="100px" ></a></p>
 <p>Tokenize sentences in Latin and Devanagari scripts using <strong><code>wink-tokenizer</code></strong>. It is a part of <a href="http://winkjs.org/">wink</a> — a growing family of high quality packages for Statistical Analysis, Natural Language Processing and Machine Learning in NodeJS.</p>
 <p>Some of it's top feature are:</p>
@@ -808,6 +818,107 @@ using <code>regexes</code>, which is otherwise a complex and time consuming task
 <span class="hljs-comment">// under tokenize().</span>
 myTokenizer.getTokensFP();
 <span class="hljs-comment">// -&gt; 'wwww,wwuw!'</span></pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='addregex'>
+      addRegex
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Allows to add a new regex that will map to a existing
+or new tag</p>
+
+
+  <div class='pre p1 fill-light mt0'>addRegex(regex: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a>, tag: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, fingerprintCode: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): void</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>regex</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a>)</code>
+	    — The new regex.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>tag</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    — The tag that the new regex will match to.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>fingerprintCode</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
+	    — Used if adding a new tag. Ignored if using an existing tag.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code>void</code>:
+        
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Adding a regex for an existing tag</span>
+myTokenizer.addRegex(<span class="hljs-regexp">/\(oo\)/gi</span>, <span class="hljs-string">'emoticon'</span>);
+myTokenizer.tokenize(<span class="hljs-string">'(oo)'</span>)
+<span class="hljs-comment">// -&gt; [ { value: '(oo)', tag: 'emoticon' } ]</span>
+<span class="hljs-comment">// Adding a regex that will match to a new tag</span>
+myTokenizer.addRegex(<span class="hljs-comment">//gi, 'custom', 'q);</span>
+myTokenizer.tokenize(<span class="hljs-string">'(oo)'</span>)
+<span class="hljs-comment">// -&gt; [ { value: '(oo)', tag: 'emoticon' } ]</span></pre>
     
   
 

--- a/src/wink-tokenizer.js
+++ b/src/wink-tokenizer.js
@@ -82,6 +82,7 @@ var rgxsMaster = [
   { regex: rgxPunctuation, category: 'punctuation' },
   { regex: rgxSymbol, category: 'symbol' }
 ];
+
 // Used to generate finger print from the tokens.
 var fingerPrintCodes = {
   emoticon: 'c',
@@ -372,9 +373,48 @@ var tokenizer = function () {
     return fp.join( '' );
   }; // getFingerprint()
 
+  var addTag = function (name, fingerprintCode) {
+    if (fingerPrintCodes[name]) {
+      throw new Error( 'Tag ' + name + ' already exists' );
+    }
+
+    fingerPrintCodes[name] = fingerprintCode;
+  };
+
+  // ### addRegex
+  /**
+   * Allows to add a new regex that will map to a existing
+   * or new tag
+   * @param {RegExp} regex — The new regex.
+   * @param {string} tag — The tag that the new regex will match to.
+   * @param {string} [fingerprintCode] — Used if adding a new tag. Ignored if using an existing tag.
+   * @return {void}
+   * @example
+   * // Adding a regex for an existing tag
+   * myTokenizer.addRegex(/\(oo\)/gi, 'emoticon');
+   * myTokenizer.tokenize('(oo)')
+   * // -> [ { value: '(oo)', tag: 'emoticon' } ]
+   * // Adding a regex that will match to a new tag
+   * myTokenizer.addRegex(//gi, 'custom', 'q);
+   * myTokenizer.tokenize('(oo)')
+   * // -> [ { value: '(oo)', tag: 'emoticon' } ]
+  */
+
+  var addRegex = function (regex, tag, fingerprintCode) {
+    if (!fingerPrintCodes[tag] && !fingerprintCode) {
+      throw new Error( 'Tag ' + tag + ' doesn\'t exist; Provide a \'fingerprintCode\' to add it as a tag.' );
+    } else if (!fingerPrintCodes[tag]) {
+      addTag(tag, fingerprintCode);
+    }
+
+    rgxs.unshift( { regex: regex, category: tag } );
+  };
+
   methods.defineConfig = defineConfig;
   methods.tokenize = tokenize;
   methods.getTokensFP = getTokensFP;
+  methods.addTag = addTag;
+  methods.addRegex = addRegex;
   return methods;
 };
 

--- a/test/wink-tokenizer-specs.js
+++ b/test/wink-tokenizer-specs.js
@@ -118,6 +118,55 @@ describe( 'wink tokenizer', function () {
     expect( fp() ).to.equal( 'm:wwwwwwe;&wwwwjwwtc' );
   } );
 
+  it( 'should tokenize a complex sentence when adding a custom regex', function () {
+    var output = [ { value: '@superman', tag: 'mention' },
+                   { value: ':', tag: 'punctuation' },
+                   { value: 'come', tag: 'word' },
+                   { value: 'help', tag: 'word' },
+                   { value: 'me', tag: 'word' },
+                   { value: 'out', tag: 'word' },
+                   { value: 'I', tag: 'word' },
+                   { value: '\'m', tag: 'word' },
+                   { value: 'sick', tag: 'word' },
+                   { value: '+o(', tag: 'emoticon' },
+                   { value: ';', tag: 'punctuation' },
+                   { value: '(oo)', tag: 'emoticon' },
+                   { value: '<-', tag: 'emoticon' }
+                  ];
+
+    tokenizer.addRegex(/:\||O\.O|:`\(|\+o\(|\(oo\)|:%|:\$|>\|<|<-/gi, 'emoticon');
+    expect( tokenizer.tokenize( '@superman: come help me out I\'m sick +o(; (oo) <-' ) ).to.deep.equal( output );
+  } );
+
+  it( 'should throw an error when adding a regex with an inexisting tag', function () {
+    expect( function () {
+      tokenizer.addRegex(/\(oo\)/gi, 'pig');
+    } ).to.throw('Tag pig doesn\'t exist; Provide a \'fingerprintCode\' to add it as a tag.');
+  } );
+
+  it( 'should throw an error when adding a tag that already exists', function () {
+    expect( function () {
+      tokenizer.addTag('emoticon', 8);
+    } ).to.throw('Tag emoticon already exists');
+  } );
+
+  it( 'should tokenize a complex sentence when adding a custom regex with a new tag', function () {
+    var output = [ { value: 'I', tag: 'word' },
+                   { value: '\'m', tag: 'word' },
+                   { value: 'thinking', tag: 'word' },
+                   { value: 'why', tag: 'word' },
+                   { value: 'superman', tag: 'superman' },
+                   { value: '\'', tag: 'punctuation' },
+                   { value: 's', tag: 'word' },
+                   { value: 'dead', tag: 'word' },
+                   { value: '?', tag: 'punctuation' },
+                   { value: '!', tag: 'punctuation' }
+                  ];
+
+    tokenizer.addRegex(/superman/gi, 'superman', 's');
+    expect( tokenizer.tokenize( 'I\'m thinking why superman\'s dead ?!' ) ).to.deep.equal( output );
+  } );
+
   it( 'should tokenize a complex sentence with empty config', function () {
     var output = [ { value: '@superman:', tag: 'alien' },
                    { value: 'hit', tag: 'alien' },


### PR DESCRIPTION
Hi @sanjayaksaxena 
I am thinking of using your library to help us parse strings in order to replace some specific "tags" to images (custom emoticons). It would help tremendously in cutting the amount of code I'd need to write, but since your library doesn't cover all the possible strings I'd need, I took the liberty to fork and extend it a little bit.

The idea is to be able to add custom regexes that will map to an existing `tag` (or create a new one at the same time a regex is added). I added some JSDoc and updated the tests accordingly (still 100% coverage)

Thank you for your time!