### PR TITLE
Add support for newer emoji styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -598,10 +598,9 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+      "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w=="
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -2752,6 +2751,12 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -3193,6 +3198,12 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "string-width": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "mocha": "^6.1.3",
     "mocha-lcov-reporter": "^1.3.0"
   },
-  "runkitExampleFilename": "./runkit/example.js"
+  "runkitExampleFilename": "./runkit/example.js",
+  "dependencies": {
+    "emoji-regex": "^9.0.0"
+  }
 }

--- a/src/wink-tokenizer.js
+++ b/src/wink-tokenizer.js
@@ -24,6 +24,7 @@
 //     DEALINGS IN THE SOFTWARE.
 
 //
+var emojiRegex = require( 'emoji-regex' );
 var contractions = require( './eng-contractions.js' );
 var rgxSpaces = /\s+/g;
 // Ordinals only for Latin like 1st, 2nd or 12th or 33rd.
@@ -50,7 +51,7 @@ var rgxPunctuation = /[’'‘’`“”"\[\]\(\){}…,\.!;\?\-:\u0964\u0965]/g;
 var rgxQuotedPhrase = /"[^"]*"/g;
 // NOTE: URL will support only EN character set for now.
 var rgxURL = /(?:https?:\/\/)(?:[\da-z\.-]+)\.(?:[a-z\.]{2,6})(?:[\/\w\.\-\?#=]*)*\/?/gi;
-var rgxEmoji = /[\uD800-\uDBFF][\uDC00-\uDFFF]|[\u2600-\u26FF]|[\u2700-\u27BF]/g;
+var rgxEmoji = emojiRegex();
 var rgxEmoticon = /:-?[dps\*\/\[\]{}\(\)]|;-?[/(/)d]|<3/gi;
 var rgxTime = /(?:\d|[01]\d|2[0-3]):?(?:[0-5][0-9])?\s?(?:[ap]\.?m\.?|hours|hrs)/gi;
 // Inlcude [Latin-1 Supplement Unicode Block](https://en.wikipedia.org/wiki/Latin-1_Supplement_(Unicode_block))

--- a/test/wink-tokenizer-specs.js
+++ b/test/wink-tokenizer-specs.js
@@ -488,4 +488,11 @@ describe( 'wink tokenizer', function () {
                    { value: '"', tag: 'punctuation' } ];
     expect( t().tokenize( 'He said, "buy two/three apples"' ) ).to.deep.equal( output );
   } );
+
+  it( 'should tokenize combined emojis ', function () {
+    var output = [ { value: '👩🏿', tag: 'emoji' },
+                   { value: '↔️', tag: 'emoji' },
+                   { value: '🕵🏽', tag: 'emoji' } ];
+    expect( t().tokenize( '👩🏿↔️🕵🏽' ) ).to.deep.equal( output );
+  } );
 } );


### PR DESCRIPTION
This PR is a fix for #30 

It works by expanding the regex used to detect emojis to include newer unicode symbols.

Given that emojis are added fairly regularly, it makes sense to rely on a popular library to provide maintenance here. Alternatively, it could be possible to copy in the whole regex, but it would require manually updating in the future.